### PR TITLE
Setsu Scans: fix status selector

### DIFF
--- a/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
+++ b/multisrc/overrides/madara/setsuscans/src/SetsuScans.kt
@@ -1,0 +1,7 @@
+package eu.kanade.tachiyomi.extension.en.setsuscans
+
+import eu.kanade.tachiyomi.multisrc.madara.Madara
+
+class SetsuScans : Madara("Setsu Scans", "https://setsuscans.com", "en") {
+    override val mangaDetailsSelectorStatus = "div.summary-heading:contains(status) + div.summary-content"
+}

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -14,7 +14,7 @@ class MadaraGenerator : ThemeSourceGenerator {
     override val sources = listOf(
         SingleLang("DragonTea", "https://dragontea.ink", "en", overrideVersionCode = 3),
         SingleLang("Reset Scans", "https://reset-scans.com", "en"),
-        SingleLang("Setsu Scans", "https://setsuscans.com", "en", overrideVersionCode = 1),
+        SingleLang("Setsu Scans", "https://setsuscans.com", "en", overrideVersionCode = 2),
     )
 
     companion object {


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
